### PR TITLE
Add Dockerfile and app.py for gpt-oss-20B chat interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM nvidia/cuda:12.1.0-base-ubuntu22.04
+
+# Sistem paketleri
+RUN apt-get update && \
+    apt-get install -y git python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Python kısayolu
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Gerekli Python kütüphaneleri
+RUN pip install --upgrade pip && \
+    pip install transformers accelerate sentencepiece gradio
+
+# Çalışma dizini
+WORKDIR /app
+
+# Model dosyalarını önceden indirmek (isteğe bağlı, cache amaçlı)
+# RUN python - <<EOF
+# from transformers import AutoTokenizer, AutoModelForCausalLM
+# model_name = "gpt-oss/gpt-oss-20b"
+# AutoTokenizer.from_pretrained(model_name)
+# AutoModelForCausalLM.from_pretrained(model_name)
+# EOF
+
+# Ana uygulama dosyasını kopyala
+COPY app.py /app/app.py
+
+# Container başlatıldığında çalışacak komut
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+import gradio as gr
+from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
+
+MODEL_NAME = "gpt-oss/gpt-oss-20b"
+
+# Model ve tokenizer'ı yükle
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME,
+    device_map="auto",
+    torch_dtype="auto"
+)
+
+# Text generation pipeline
+generator = pipeline(
+    "text-generation",
+    model=model,
+    tokenizer=tokenizer,
+    max_new_tokens=256,
+    temperature=0.8,
+    top_p=0.95
+)
+
+# Gradio arayüzü için fonksiyon
+def chat_fn(history, user_input):
+    prompt = user_input
+    response = generator(prompt)[0]["generated_text"]
+    # Basitçe, kullanıcının prompt'unu ve modeli yanıtını kaydet
+    history = history + [(user_input, response)]
+    return history, ""
+
+with gr.Blocks() as demo:
+    gr.Markdown("# gpt-oss-20B Chat")
+    chatbot = gr.Chatbot()
+    msg = gr.Textbox(label="Prompt", placeholder="Merhaba...")
+    state = gr.State([])
+
+    def submit_fn(user_message, history):
+        history, _ = chat_fn(history, user_message)
+        return history, history
+
+    msg.submit(submit_fn, [msg, state], [chatbot, state])
+
+# Web arayüzü
+demo.launch(server_name="0.0.0.0", server_port=7860)


### PR DESCRIPTION
## Summary
- Add Dockerfile with dependencies and startup for gpt-oss-20B model
- Add Gradio-based app.py to chat with the model

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689478d6bc00832db151d356d44e7533