### PR TITLE
Quantize model loading to reduce memory usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,9 @@ import gradio as gr
 from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
 from huggingface_hub import login
 
+import torch
+import bitsandbytes as bnb
+
 MODEL_NAME = "openai/gpt-oss-20b"
 HF_TOKEN = os.getenv("HF_TOKEN")
 
@@ -14,7 +17,8 @@ tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, token=HF_TOKEN)
 model = AutoModelForCausalLM.from_pretrained(
     MODEL_NAME,
     device_map="auto",
-    torch_dtype="auto",
+    load_in_8bit=True,
+    torch_dtype=torch.float16,
     token=HF_TOKEN
 )
 


### PR DESCRIPTION
## Summary
- import torch and bitsandbytes to enable low-precision loading
- load the causal language model in 8-bit float16 to cut memory use

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'\nimport bitsandbytes, torch\nprint('bitsandbytes', bitsandbytes.__version__)\nprint('torch', torch.__version__)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_6894cbfdd0d8832d86e165a2c02f67bf